### PR TITLE
Change icon app name

### DIFF
--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">ChartIQ</string>
+    <string name="app_name">ChartIQ Demo</string>
 
     <string name="title_chart">Chart</string>
     <string name="title_study">Studies</string>


### PR DESCRIPTION
Change from "ChartIQ" to "ChartIQ Demo"

Test this by deploying locally against an emulator/real device and check the name under the icon on the mobile home page. 