### PR TITLE
38451 Missing tick periodicity

### DIFF
--- a/chartiq/src/main/java/com/chartiq/sdk/model/TimeUnit.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/model/TimeUnit.kt
@@ -4,6 +4,7 @@ package com.chartiq.sdk.model
  * An enumeration for available time units
  */
 enum class TimeUnit {
+    TICK,
     SECOND,
     MINUTE,
     HOUR,

--- a/demo/src/main/java/com/chartiq/demo/ui/chart/interval/list/Util.kt
+++ b/demo/src/main/java/com/chartiq/demo/ui/chart/interval/list/Util.kt
@@ -7,6 +7,7 @@ import com.chartiq.sdk.model.TimeUnit
 fun getTimeUnitText(resources: Resources, interval: Int, timeUnit: TimeUnit): String {
     with(resources) {
         return when (timeUnit) {
+            TimeUnit.TICK -> getString(R.string.interval_tick, interval)
             TimeUnit.SECOND -> getString(R.string.interval_second, interval)
             TimeUnit.MINUTE -> getString(R.string.interval_minute, interval)
             TimeUnit.HOUR -> getString(R.string.interval_hour, interval)

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="title_intervals">Intervals</string>
     <string name="title_custom_intervals">Custom Intervals</string>
     <string name="interval_full_label">%d %s</string>
+    <string name="interval_tick">tick</string>
     <string name="interval_second">second</string>
     <string name="interval_minute">minute</string>
     <string name="interval_hour">hour</string>


### PR DESCRIPTION
Add entry for tick periodicity

To test put this line in the `DEFAULT_INTERVAL_LIST` object in **ChooseIntervalFragment.kt**

`Interval(1, 1, TimeUnit.TICK)`