### PR TITLE
42028 Android addStudy needs json string

### DIFF
--- a/chartiq/src/main/java/com/chartiq/sdk/ChartIQHandler.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/ChartIQHandler.kt
@@ -381,7 +381,15 @@ class ChartIQHandler(
         } else {
             study.shortName
         }
-        val scripts = scriptManager.getAddStudyScript(key)
+
+        var inputs = ""
+        var outputs = ""
+        var parameters = ""
+
+        if(!study.inputs.isNullOrEmpty()) inputs = Gson().toJson(study.inputs)
+        if(!study.outputs.isNullOrEmpty()) outputs = Gson().toJson(study.outputs)
+        if(!study.parameters.isNullOrEmpty()) parameters = Gson().toJson(study.parameters)
+        val scripts = scriptManager.getAddStudyScript(key, inputs, outputs, parameters)
         executeJavascript(scripts)
     }
 

--- a/chartiq/src/main/java/com/chartiq/sdk/scriptmanager/ChartIQScriptManager.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/scriptmanager/ChartIQScriptManager.kt
@@ -85,8 +85,8 @@ internal class ChartIQScriptManager : ScriptManager {
     override fun getSetChartScaleScript(scale: String): String =
         CHART_IQ_JS_OBJECT + "setChartScale(\"$scale\");"
 
-    override fun getAddStudyScript(studyName: String): String =
-        MOBILE_BRIDGE_NAME_SPACE + "addStudy(\"$studyName\");"
+    override fun getAddStudyScript(studyName: String, inputs: String, outputs: String, parameters: String): String =
+        MOBILE_BRIDGE_NAME_SPACE + "addStudy(\"$studyName\", '$inputs', '$outputs', '$parameters');"
 
     override fun getRemoveStudyScript(studyName: String): String =
         MOBILE_BRIDGE_NAME_SPACE + "removeStudy(\"$studyName\");"

--- a/chartiq/src/main/java/com/chartiq/sdk/scriptmanager/ChartIQScriptManager.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/scriptmanager/ChartIQScriptManager.kt
@@ -86,7 +86,7 @@ internal class ChartIQScriptManager : ScriptManager {
         CHART_IQ_JS_OBJECT + "setChartScale(\"$scale\");"
 
     override fun getAddStudyScript(studyName: String, inputs: String, outputs: String, parameters: String): String =
-        MOBILE_BRIDGE_NAME_SPACE + "addStudy(\"$studyName\", '$inputs', '$outputs', '$parameters');"
+        MOBILE_BRIDGE_NAME_SPACE + "addStudy('$studyName', '$inputs', '$outputs', '$parameters');"
 
     override fun getRemoveStudyScript(studyName: String): String =
         MOBILE_BRIDGE_NAME_SPACE + "removeStudy(\"$studyName\");"

--- a/chartiq/src/main/java/com/chartiq/sdk/scriptmanager/ScriptManager.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/scriptmanager/ScriptManager.kt
@@ -57,7 +57,7 @@ internal interface ScriptManager {
 
     fun getSetChartScaleScript(scale: String): String
 
-    fun getAddStudyScript(studyName: String): String
+    fun getAddStudyScript(studyName: String, inputs: String, outputs: String, parameters: String): String
 
     fun getRemoveStudyScript(studyName: String): String
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 01 19:59:21 EEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
addStudy function for Android now takes inputs, outputs, and parameters properly. 

How to test:
Put the below code in the addStudy method in ChartIQHandler.kt, launch the application, and add a moving average study.  The output should be blue in color. 
```
val outputTest = HashMap<String, Any>()
outputTest["MA"] = "#1C85E7"
study.outputs = outputTest
```