### PR TITLE
50195 Study icon and clone

### DIFF
--- a/chartiq/src/main/java/com/chartiq/sdk/ChartIQHandler.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/ChartIQHandler.kt
@@ -525,6 +525,11 @@ class ChartIQHandler(
 
     override fun addStudy(study: Study, forClone: Boolean) {
         val key = if (forClone) {
+            if(!study.inputs.isNullOrEmpty()) {
+                val studyMap = study.inputs?.toMutableMap()
+                studyMap?.put("id", "") // change the id so the study can be cloned and not just updated
+                study.inputs = studyMap
+            }
             study.type!!
         } else {
             study.shortName
@@ -534,9 +539,9 @@ class ChartIQHandler(
         var outputs = ""
         var parameters = ""
 
-        if(!study.inputs.isNullOrEmpty() && !forClone) inputs = Gson().toJson(study.inputs)
-        if(!study.outputs.isNullOrEmpty() && !forClone) outputs = Gson().toJson(study.outputs)
-        if(!study.parameters.isNullOrEmpty() && !forClone) parameters = Gson().toJson(study.parameters)
+        if(!study.inputs.isNullOrEmpty()) inputs = Gson().toJson(study.inputs)
+        if(!study.outputs.isNullOrEmpty()) outputs = Gson().toJson(study.outputs)
+        if(!study.parameters.isNullOrEmpty()) parameters = Gson().toJson(study.parameters)
         val scripts = scriptManager.getAddStudyScript(key, inputs, outputs, parameters)
         executeJavascript(scripts)
     }

--- a/chartiq/src/main/java/com/chartiq/sdk/ChartIQHandler.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/ChartIQHandler.kt
@@ -534,9 +534,9 @@ class ChartIQHandler(
         var outputs = ""
         var parameters = ""
 
-        if(!study.inputs.isNullOrEmpty()) inputs = Gson().toJson(study.inputs)
-        if(!study.outputs.isNullOrEmpty()) outputs = Gson().toJson(study.outputs)
-        if(!study.parameters.isNullOrEmpty()) parameters = Gson().toJson(study.parameters)
+        if(!study.inputs.isNullOrEmpty() && !forClone) inputs = Gson().toJson(study.inputs)
+        if(!study.outputs.isNullOrEmpty() && !forClone) outputs = Gson().toJson(study.outputs)
+        if(!study.parameters.isNullOrEmpty() && !forClone) parameters = Gson().toJson(study.parameters)
         val scripts = scriptManager.getAddStudyScript(key, inputs, outputs, parameters)
         executeJavascript(scripts)
     }

--- a/demo/src/single_page_demo/res/layout-sw600dp-land/fragment_chart.xml
+++ b/demo/src/single_page_demo/res/layout-sw600dp-land/fragment_chart.xml
@@ -63,16 +63,8 @@
                 style="@style/ChartCheckBoxStyle"
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="@dimen/margin_medium_small"
-                android:layout_toStartOf="@+id/compareCheckBox"
+                android:layout_toStartOf="@+id/signalCheckBox"
                 android:button="@drawable/ic_nav_study" />
-
-            <androidx.appcompat.widget.AppCompatCheckBox
-                android:id="@+id/compareCheckBox"
-                style="@style/ChartCheckBoxStyle"
-                android:layout_centerVertical="true"
-                android:layout_marginEnd="@dimen/margin_medium_small"
-                android:layout_toStartOf="@+id/crosshairCheckBox"
-                android:button="@drawable/ic_compare" />
 
             <androidx.appcompat.widget.AppCompatCheckBox
                 android:id="@+id/signalCheckBox"
@@ -81,6 +73,14 @@
                 android:layout_marginEnd="@dimen/margin_medium_small"
                 android:layout_toStartOf="@+id/compareCheckBox"
                 android:button="@drawable/ic_nav_signal" />
+
+            <androidx.appcompat.widget.AppCompatCheckBox
+                android:id="@+id/compareCheckBox"
+                style="@style/ChartCheckBoxStyle"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="@dimen/margin_medium_small"
+                android:layout_toStartOf="@+id/crosshairCheckBox"
+                android:button="@drawable/ic_compare" />
 
             <androidx.appcompat.widget.AppCompatCheckBox
                 android:id="@+id/crosshairCheckBox"


### PR DESCRIPTION
Issues fixed.

1. Don't pass inputs and outputs when cloning a study. 
2. Fix the tablet landscape ui view so that the study icon is hidden. (Note: for some reason tablet emulators on Android studio don't rotate when the orientation is changed, you may have to use a physical device for testing.)