### PR TITLE
52738-arabic-locale-issues

### DIFF
--- a/demo/src/main/java/com/chartiq/demo/ui/settings/language/ChartIQLanguage.kt
+++ b/demo/src/main/java/com/chartiq/demo/ui/settings/language/ChartIQLanguage.kt
@@ -11,5 +11,5 @@ enum class ChartIQLanguage(val title: String, val code: String) {
     HU("Hungarian", "hu-HU"),
     ZH("Chinese", "zh-CN"),
     JA("Japanese", "ja-JP"),
-    AR("Arabic", "ar-EG"),
+    AR("Arabic", "ar-EG-u-nu-latn"),
 }


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/15/cards/52738/details/

Change the locale from 'ar-EG' to 'ar-EG-u-nu-latn' to address the x-axis date format issues and the y-axis number display for Arabic