### PR TITLE
53975 incorrect arrow drawing tool name

### DIFF
--- a/chartiq/CHANGELOG.md
+++ b/chartiq/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 All notable changes to "ChartIQ SDK" will be documented in this file.
 
+## [3.8.0] - Jul 3, 2025
+
+Requires ChartIQ version 9.8.0 or later
+
+### Fixed
+
+- Arrow drawing tool fixed
+
 ## [3.3.1] - Jan 4, 2024
 
 Requires ChartIQ version 8.8.0 or later
+
 ### Fixed
 
 - Crosshair functionality on/off issues

--- a/chartiq/build.gradle.kts
+++ b/chartiq/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("kotlin-android-extensions")
     id("org.jetbrains.dokka")
 }
-extra.set("version_name", "3.7.0")
+extra.set("version_name", "3.8.0")
 
 android {
     compileSdk = 34

--- a/chartiq/src/main/java/com/chartiq/sdk/model/drawingtool/DrawingTool.kt
+++ b/chartiq/src/main/java/com/chartiq/sdk/model/drawingtool/DrawingTool.kt
@@ -10,7 +10,7 @@ enum class DrawingTool(
     val value: String?
 ) {
     ANNOTATION("annotation"),
-    ARROW("arrow"),
+    ARROW("arrowline"),
     AVERAGE_LINE("average"),
     CALLOUT("callout"),
     CHANNEL("channel"),


### PR DESCRIPTION
Update arrow tool to correct name listed in ChartIQ SDK.

Fixed when arrow drawing tool and settings can be set again on the chart. 